### PR TITLE
Adjustment to parse + like space

### DIFF
--- a/Net.Http.WebApi.OData/Query/ODataQueryOptions.cs
+++ b/Net.Http.WebApi.OData/Query/ODataQueryOptions.cs
@@ -43,7 +43,7 @@ namespace Net.Http.WebApi.OData.Query
                 throw new ArgumentNullException("request");
             }
 
-            var rawQuery = Uri.UnescapeDataString(request.RequestUri.Query);
+            var rawQuery = Uri.UnescapeDataString(request.RequestUri.Query).Replace('+', ' ');
 
             this.request = request;
             this.rawValues = new ODataRawQueryOptions(rawQuery);


### PR DESCRIPTION
Adjustment to parse + like space, some browsers encode space like plus, when Uri comes like $filter=SomeField+eq+42 then it's need to be parse like $filter=SomeField eq 42
References
https://msdn.microsoft.com/en-us/library/system.uri.unescapedatastring(v=vs.110).aspx
http://stackoverflow.com/questions/34878771/angular-encode-space-as-not-20
http://stackoverflow.com/questions/2678551/when-to-encode-space-to-plus-or-20